### PR TITLE
🚀 Fix Vercel deployment runtime configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,10 @@
     "**/.server/**/*.tsx",
     "**/.client/**/*.ts",
     "**/.client/**/*.tsx"
+  ],
+  "exclude": [
+    "functions",
+    "build",
+    "node_modules"
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,19 +1,7 @@
 {
-  "buildCommand": "pnpm run build",
-  "outputDirectory": "build/client",
-  "installCommand": "pnpm install",
   "framework": "remix",
-  "functions": {
-    "build/server/index.js": {
-      "runtime": "nodejs18.x"
-    }
-  },
-  "rewrites": [
-    {
-      "source": "/((?!build/).*)",
-      "destination": "/build/server/index.js"
-    }
-  ],
+  "buildCommand": "pnpm run build",
+  "installCommand": "pnpm install",
   "headers": [
     {
       "source": "/build/(.*)",


### PR DESCRIPTION
- Removed invalid 'nodejs18.x' runtime specification (AWS Lambda format)
- Simplified vercel.json to use Vercel's auto-detection for Remix
- Kept essential headers configuration for static assets
- Removed manual function configuration to let Vercel handle Remix properly
- Added exclude for functions directory in tsconfig.json to fix TypeScript errors

✅ This should resolve the 'Function Runtimes must have a valid version' error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude certain directories from TypeScript compilation.
  * Simplified deployment settings by removing custom output, runtime, and rewrite configurations, relying on default framework behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->